### PR TITLE
Allow hashes ('#' characters) in the content of headings.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,3 +6,8 @@
 # 1.0.2
 
 -   Fix inappropriate translation of image URLs into local paths.
+
+
+# 1.0.3
+
+- Allow hashes (`#` characters) in the content of headings.

--- a/foliant/preprocessors/includes.py
+++ b/foliant/preprocessors/includes.py
@@ -15,7 +15,7 @@ class Preprocessor(BasePreprocessor):
     tags = 'include',
 
     _heading_pattern = re.compile(
-        r'^(?P<hashes>\#+)\s*(?P<title>[^\#]+)\s*$',
+        r'^(?P<hashes>\#+)\s*(?P<title>[^\#]+.+)\s*$',
         flags=re.MULTILINE
     )
     _image_pattern = re.compile(r'\!\[(?P<caption>.*)\]\((?P<path>((?!:\/\/).)+)\)')


### PR DESCRIPTION
Headings may contain hashes, why not?

`### Heading {#custom_id}`
`## This feature is #1 in the world!`