### PR TITLE
Fix the patterns for detection of headings. Do not allow headings with level > 6

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 -   Require at least one space after hashes in the beginning of each heading.
 -   Add `inline` option to the `<include>` tag.
+-   Fix the bug: do not ignore empty lines after headings when using `sethead`.
+-   Fix the bug: allow to use less than 3 characters in the heading content.
+-   Do not mark as headings the strings that contain more than 6 leading hashes. If shifted heading level is more than 6, mark the heading content as bold paragraph text, not as heading.
 
 # 1.0.7
 


### PR DESCRIPTION
1. The bug encountered: the `flatten` preprocessor loses empty lines after headings. In some cases it is critical for making PDFs with Pandoc. The reason is that empty lines pass away when the `includes` preprocessor with the `sethead` option is used. It happens because of trailing whitespace characters are ignored by the `_shift_headings()` method. I added the group `<tail>` to avoid this.

2. The group `(?P<title>[^\#].+\S+)` requires at least 3 characters, and that is incorrect. I replaced it with `(?P<title>.*\S+)`. One character must be enough for the heading title.

3. Pandoc, as such as MkDocs, does not mark as headings the strings that contains more than 6 leading hashes. [Pandoc manual](https://pandoc.org/MANUAL.html#atx-style-headers): “An ATX-style header consists of *one to six* `#` signs and a line of text.” It seems right to use `#{1,6}` instead of `#+` in the patterns to detect headings. And it seems right to replace headings with bold paragraph text in `_shift_headings()` method, if shifted heading level is > 6 (this feature is also asked by @kvaleev).