### PR TITLE
add: generation of the includes map

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -1,4 +1,4 @@
-name: Python package
+name: Python package tests
 
 on: [push]
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ preprocessors:
             - j2
         aliases:
             ...
+        includes_map: true
 ```
 
 `cache_dir`
@@ -78,6 +79,11 @@ Default `true`.
         <include>$baz#master$path/to/doc.md</include>
 
     Note that in the second example the default revision (`develop`) will be overridden with the custom one (`master`).
+
+`includes_map`
+:   Enables generation of the `includes_map.json` file containing information about files inserted using the includes preprocessor.
+
+    From this file, third-party services can receive information about the presence of inclusions in files, for example, to check links using a linter.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![](https://img.shields.io/pypi/v/foliantcontrib.includes.svg)](https://pypi.org/project/foliantcontrib.includes/) [![](https://img.shields.io/github/v/tag/foliant-docs/foliantcontrib.includes.svg?label=GitHub)](https://github.com/foliant-docs/foliantcontrib.includes)
+[![](https://img.shields.io/pypi/v/foliantcontrib.includes.svg)](https://pypi.org/project/foliantcontrib.includes/) [![](https://img.shields.io/github/v/tag/foliant-docs/foliantcontrib.includes.svg?label=GitHub)](https://github.com/foliant-docs/foliantcontrib.includes) [![Tests](https://github.com/foliant-docs/foliantcontrib.includes/actions/workflows/python-test.yml/badge.svg)](https://github.com/foliant-docs/foliantcontrib.includes/actions/workflows/python-test.yml)
 
 # Includes for Foliant
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -1,4 +1,4 @@
-[![](https://img.shields.io/pypi/v/foliantcontrib.includes.svg)](https://pypi.org/project/foliantcontrib.includes/) [![](https://img.shields.io/github/v/tag/foliant-docs/foliantcontrib.includes.svg?label=GitHub)](https://github.com/foliant-docs/foliantcontrib.includes)
+[![](https://img.shields.io/pypi/v/foliantcontrib.includes.svg)](https://pypi.org/project/foliantcontrib.includes/) [![](https://img.shields.io/github/v/tag/foliant-docs/foliantcontrib.includes.svg?label=GitHub)](https://github.com/foliant-docs/foliantcontrib.includes) [![Tests](https://github.com/foliant-docs/foliantcontrib.includes/actions/workflows/python-test.yml/badge.svg)](https://github.com/foliant-docs/foliantcontrib.includes/actions/workflows/python-test.yml)
 
 # Препроцессор Includes для Foliant
 
@@ -34,6 +34,7 @@ preprocessors:
             - j2
         aliases:
             ...
+        includes_map: true
 ```
 
 `cache_dir`
@@ -63,6 +64,10 @@ preprocessors:
 
 `aliases`
 :   Сопоставление псевдонимов с URL-адресами репозитория Git. После определения этого параметра псевдоним может использоваться для ссылки на репозиторий вместо его полного URL-адреса.
+
+`includes_map`
+:   Включает генерацию файла `includes_map.json`, содержащего информацию о файлах, вставленных с помощью препроцессора includes.
+ Из этого файла сторонние сервисы могут получать информацию о наличии текста вставленного в файл с помощью препроцессора, например, для проверки ссылок с помощью линтера.
 
 >**Внимание!**
 >

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# 1.1.18
+
+- Add: option for generation of the includes map containing information about files inserted using the preprocessor.
+
 # 1.1.17
 
 - Fix: fixed a link processing error for files with diagrams

--- a/foliant/preprocessors/includes.py
+++ b/foliant/preprocessors/includes.py
@@ -990,8 +990,8 @@ class Preprocessor(BasePreprocessor):
                     else:
                         self.logger.debug('Local file referenced')
 
-                        donor_md_path = f"{self.src_dir}/{markdown_file_path.relative_to(os.getcwd()).relative_to(self.working_dir).as_posix()}"
                         included_file_path = self._get_included_file_path(body.group('path'), markdown_file_path)
+                        donor_md_path = f"{self.src_dir}/{included_file_path.relative_to(os.getcwd()).relative_to(self.working_dir).as_posix()}"
 
                         if included_file_path.name.startswith('^'):
                             included_file_path = self._find_file(

--- a/foliant/preprocessors/includes.py
+++ b/foliant/preprocessors/includes.py
@@ -966,7 +966,7 @@ class Preprocessor(BasePreprocessor):
                         
                         donor_md_path = included_file_path.as_posix()
                         
-                        self.logger.debug(f'Set the repo URL of the included file to {recipient_md_path}: {donor_md_path}')
+                        self.logger.debug(f'Set the repo URL of the included file to {recipient_md_path}: {donor_md_path} (1)')
 
                         if included_file_path.name.startswith('^'):
                             included_file_path = self._find_file(
@@ -1020,7 +1020,7 @@ class Preprocessor(BasePreprocessor):
 
                         donor_md_path = f"{self.src_dir}/{included_file_path.relative_to(os.getcwd()).relative_to(self.working_dir).as_posix()}"
                         
-                        self.logger.debug(f'Set the path of the included file to {recipient_md_path}: {donor_md_path}')
+                        self.logger.debug(f'Set the path of the included file to {recipient_md_path}: {donor_md_path} (2)')
 
                 else:  # if body is missing
                     self.logger.debug('Using the new syntax rules')
@@ -1060,7 +1060,7 @@ class Preprocessor(BasePreprocessor):
 
                         donor_md_path = include_link
                         
-                        self.logger.debug(f'Set the link of the included file to {recipient_md_path}: {donor_md_path}')
+                        self.logger.debug(f'Set the link of the included file to {recipient_md_path}: {donor_md_path} (3)')
 
                     elif options.get('url'):
                         self.logger.debug('File to get by URL referenced')
@@ -1090,7 +1090,7 @@ class Preprocessor(BasePreprocessor):
                         
                         donor_md_path = options['url']
                         
-                        self.logger.debug(f'Set the URL of the included file to {recipient_md_path}: {donor_md_path}')
+                        self.logger.debug(f'Set the URL of the included file to {recipient_md_path}: {donor_md_path} (4)')
 
                     elif options.get('src'):
                         self.logger.debug('Local file referenced')
@@ -1105,7 +1105,7 @@ class Preprocessor(BasePreprocessor):
                             else:
                                 donor_md_path = _path.as_posix()
                                 
-                        self.logger.debug(f'Set the path of the included file to {recipient_md_path}: {donor_md_path}')
+                        self.logger.debug(f'Set the path of the included file to {recipient_md_path}: {donor_md_path} (5)')
 
                         if options.get('project_root'):
                             current_project_root_path = (

--- a/foliant/preprocessors/includes.py
+++ b/foliant/preprocessors/includes.py
@@ -23,7 +23,7 @@ class Preprocessor(BasePreprocessor):
         'cache_dir': Path('.includescache'),
         'aliases': {},
         'extensions': ['md'],
-        'includes_map': True
+        'includes_map': False
     }
 
     tags = 'include',

--- a/foliant/preprocessors/includes.py
+++ b/foliant/preprocessors/includes.py
@@ -963,7 +963,7 @@ class Preprocessor(BasePreprocessor):
 
                         included_file_path = repo_path / body.group('path')
                         
-                        donor_md_path = included_file_path.as_posix() + "1"
+                        donor_md_path = included_file_path.as_posix()
 
                         if included_file_path.name.startswith('^'):
                             included_file_path = self._find_file(
@@ -990,7 +990,7 @@ class Preprocessor(BasePreprocessor):
                     else:
                         self.logger.debug('Local file referenced')
 
-                        donor_md_path = f"{self.src_dir}/{markdown_file_path.relative_to(os.getcwd()).relative_to(self.working_dir).as_posix()}"  + "2"
+                        donor_md_path = f"{self.src_dir}/{markdown_file_path.relative_to(os.getcwd()).relative_to(self.working_dir).as_posix()}"
                         included_file_path = self._get_included_file_path(body.group('path'), markdown_file_path)
 
                         if included_file_path.name.startswith('^'):
@@ -1016,7 +1016,7 @@ class Preprocessor(BasePreprocessor):
                             nohead=options.get('nohead')
                         )
 
-                else:  # if body missed
+                else:  # if body is missing
                     self.logger.debug('Using the new syntax rules')
 
                     if options.get('repo_url') and options.get('path'):
@@ -1052,7 +1052,7 @@ class Preprocessor(BasePreprocessor):
                             include_link=include_link
                         )
 
-                        donor_md_path = include_link  + "3"
+                        donor_md_path = include_link
 
                     elif options.get('url'):
                         self.logger.debug('File to get by URL referenced')
@@ -1080,21 +1080,20 @@ class Preprocessor(BasePreprocessor):
                             nohead=options.get('nohead')
                         )
                         
-                        donor_md_path = options['url']  + "4"
+                        donor_md_path = options['url']
 
                     elif options.get('src'):
                         self.logger.debug('Local file referenced')
 
-                        # donor_md_path = f"{self.src_dir}/{markdown_file_path.relative_to(os.getcwd()).relative_to(self.working_dir).as_posix()}"  + "5"
                         included_file_path = self._get_included_file_path(options.get('src'), markdown_file_path)
                         self.logger.debug(f'Resolved path to the included file: {included_file_path}')
                         
                         if included_file_path.as_posix().startswith(os.getcwd()):
                             _path = included_file_path.relative_to(os.getcwd())
                             if _path.as_posix().startswith(self.working_dir.as_posix()):
-                                donor_md_path = f"{self.src_dir}/{_path.relative_to(self.working_dir).as_posix()}" + "5"
+                                donor_md_path = f"{self.src_dir}/{_path.relative_to(self.working_dir).as_posix()}"
                             else:
-                                donor_md_path = _path.as_posix() + "6"
+                                donor_md_path = _path.as_posix()
 
                         if options.get('project_root'):
                             current_project_root_path = (

--- a/foliant/preprocessors/includes.py
+++ b/foliant/preprocessors/includes.py
@@ -855,6 +855,7 @@ class Preprocessor(BasePreprocessor):
         '''
 
         recipient_md_path = f'{self.src_dir}/{markdown_file_path.relative_to(self.working_dir).as_posix()}'
+
         markdown_file_path = markdown_file_path.resolve()
 
         self.logger.debug(f'Processing Markdown file: {markdown_file_path}')
@@ -964,6 +965,8 @@ class Preprocessor(BasePreprocessor):
                         included_file_path = repo_path / body.group('path')
                         
                         donor_md_path = included_file_path.as_posix()
+                        
+                        self.logger.debug(f'Set the repo URL of the included file to {recipient_md_path}: {donor_md_path}')
 
                         if included_file_path.name.startswith('^'):
                             included_file_path = self._find_file(
@@ -991,7 +994,6 @@ class Preprocessor(BasePreprocessor):
                         self.logger.debug('Local file referenced')
 
                         included_file_path = self._get_included_file_path(body.group('path'), markdown_file_path)
-                        donor_md_path = f"{self.src_dir}/{included_file_path.relative_to(os.getcwd()).relative_to(self.working_dir).as_posix()}"
 
                         if included_file_path.name.startswith('^'):
                             included_file_path = self._find_file(
@@ -1015,6 +1017,10 @@ class Preprocessor(BasePreprocessor):
                             sethead=current_sethead,
                             nohead=options.get('nohead')
                         )
+
+                        donor_md_path = f"{self.src_dir}/{included_file_path.relative_to(os.getcwd()).relative_to(self.working_dir).as_posix()}"
+                        
+                        self.logger.debug(f'Set the path of the included file to {recipient_md_path}: {donor_md_path}')
 
                 else:  # if body is missing
                     self.logger.debug('Using the new syntax rules')
@@ -1053,6 +1059,8 @@ class Preprocessor(BasePreprocessor):
                         )
 
                         donor_md_path = include_link
+                        
+                        self.logger.debug(f'Set the link of the included file to {recipient_md_path}: {donor_md_path}')
 
                     elif options.get('url'):
                         self.logger.debug('File to get by URL referenced')
@@ -1081,6 +1089,8 @@ class Preprocessor(BasePreprocessor):
                         )
                         
                         donor_md_path = options['url']
+                        
+                        self.logger.debug(f'Set the URL of the included file to {recipient_md_path}: {donor_md_path}')
 
                     elif options.get('src'):
                         self.logger.debug('Local file referenced')
@@ -1094,6 +1104,8 @@ class Preprocessor(BasePreprocessor):
                                 donor_md_path = f"{self.src_dir}/{_path.relative_to(self.working_dir).as_posix()}"
                             else:
                                 donor_md_path = _path.as_posix()
+                                
+                        self.logger.debug(f'Set the path of the included file to {recipient_md_path}: {donor_md_path}')
 
                         if options.get('project_root'):
                             current_project_root_path = (

--- a/foliant/preprocessors/includes.py
+++ b/foliant/preprocessors/includes.py
@@ -22,8 +22,7 @@ class Preprocessor(BasePreprocessor):
         'allow_failure': True,
         'cache_dir': Path('.includescache'),
         'aliases': {},
-        'extensions': ['md'],
-        'includes_map': True
+        'extensions': ['md']
     }
 
     tags = 'include',
@@ -47,9 +46,13 @@ class Preprocessor(BasePreprocessor):
         self._cache_dir_path = self.project_path / self.options['cache_dir']
         self._downloaded_dir_path = self._cache_dir_path / '_downloaded_content'
         self.src_dir = self.config.get("src_dir")
-        self.includes_map_enable = self.options['includes_map']
-        if self.includes_map_enable:
+        self.includes_map_enable = False
+        self.includes_map_anchors = False
+        if 'includes_map' in self.options:
+            self.includes_map_enable = True
             self.includes_map = []
+            if 'anchors' in self.options['includes_map']:
+                self.includes_map_anchors = True
 
         self.logger = self.logger.getChild('includes')
 
@@ -169,7 +172,7 @@ class Preprocessor(BasePreprocessor):
 
                 for line in dict_new_link:
                     downloaded_content = downloaded_content.replace(line, dict_new_link[line])
-                # End of the conversion code block         
+                # End of the conversion code block
 
                 with open(downloaded_file_path, 'w', encoding='utf8') as downloaded_file:
 
@@ -223,6 +226,8 @@ class Preprocessor(BasePreprocessor):
                     )
 
                 except CalledProcessError as exception:
+                    self.logger.warning(str(exception))
+                except Exception as exception:
                     self.logger.warning(str(exception))
 
             else:
@@ -691,7 +696,7 @@ class Preprocessor(BasePreprocessor):
             )
 
         self.logger.debug(f'Finally, included file path: {included_file_path}')
-        
+
         return included_file_path
 
     def _process_include(
@@ -730,8 +735,8 @@ class Preprocessor(BasePreprocessor):
             f'Included file path: {included_file_path}, from heading: {from_heading}, ' +
             f'to heading: {to_heading}, sethead: {sethead}, nohead: {nohead}'
         )
-        
-    
+
+
         if included_file_path.exists():
             included_file_path = included_file_path
         else:
@@ -764,9 +769,9 @@ class Preprocessor(BasePreprocessor):
 
                 old_found_link = regexp_find_link.findall(included_content)
 
-                for line in old_found_link:          
+                for line in old_found_link:
                     relative_path = regexp_find_path.findall(line)
-                    
+
                     for ex_line in relative_path:
                         exceptions_characters = re.findall(r'https?://[^\s]+|@|:|\.png|\.jpeg|.svg', ex_line)
                         if exceptions_characters:
@@ -778,7 +783,7 @@ class Preprocessor(BasePreprocessor):
 
                 for line in dict_new_link:
                     included_content = included_content.replace(line, dict_new_link[line])
-            # End of the conversion code block                    
+            # End of the conversion code block
 
             if self.config.get('escape_code', False):
                 if isinstance(self.config['escape_code'], dict):
@@ -861,6 +866,27 @@ class Preprocessor(BasePreprocessor):
                 return True
         return False
 
+    def _find_anchors(self, content: str) -> list:
+        anchors_list = []
+
+        anchors = re.findall(r'\<anchor\>([\-\_A-Za-z0-9]+)\<\/anchor\>', content)
+        for anchor in anchors:
+            anchors_list.append(anchor)
+        custom_ids = re.findall(r'\{\#([\-A-Za-z0-9]+)\}', content)
+        for anchor in custom_ids:
+            anchors_list.append(anchor)
+        elements_with_ids = re.findall(r'id\=[\"\']([\-A-Za-z0-9]+)[\"\']', content)
+        for anchor in elements_with_ids:
+            anchors_list.append(anchor)
+        return anchors_list
+
+    def _add_anchors(self, l: list, content: str) -> list:
+        anchors = self._find_anchors(content)
+        if len(anchors) > 0:
+            for anchor in anchors:
+                l.append(anchor)
+        return l
+
     def process_includes(
             self,
             markdown_file_path: Path,
@@ -881,7 +907,10 @@ class Preprocessor(BasePreprocessor):
         '''
 
         if self.includes_map_enable:
-            recipient_md_path = f'{self.src_dir}/{markdown_file_path.relative_to(self.working_dir).as_posix()}'
+            if markdown_file_path.as_posix().startswith(self.working_dir.as_posix()):
+                recipient_md_path = f'{self.src_dir}/{markdown_file_path.relative_to(self.working_dir).as_posix()}'
+            else:
+                recipient_md_path = f'{self.src_dir}/{markdown_file_path.as_posix()}'
 
         markdown_file_path = markdown_file_path.resolve()
 
@@ -902,6 +931,7 @@ class Preprocessor(BasePreprocessor):
             if include_statement:
                 if self.includes_map_enable:
                     donor_md_path = None
+                    donor_anchors = []
 
                 current_project_root_path = project_root_path
 
@@ -985,10 +1015,13 @@ class Preprocessor(BasePreprocessor):
                         self.logger.debug(f'Local path of the repo: {repo_path}')
 
                         included_file_path = repo_path / body.group('path')
-                        
+
                         if self.includes_map_enable:
                             donor_md_path = included_file_path.as_posix()
                             self.logger.debug(f'Set the repo URL of the included file to {recipient_md_path}: {donor_md_path} (1)')
+
+                            if self.includes_map_anchors:
+                                donor_anchors = self._add_anchors(donor_anchors, processed_content_part)
 
                         if included_file_path.name.startswith('^'):
                             included_file_path = self._find_file(
@@ -1044,6 +1077,9 @@ class Preprocessor(BasePreprocessor):
                             donor_md_path = self._prepare_path_for_includes_map(included_file_path)
                             self.logger.debug(f'Set the path of the included file to {recipient_md_path}: {donor_md_path} (2)')
 
+                            if self.includes_map_anchors:
+                                donor_anchors = self._add_anchors(donor_anchors, processed_content_part)
+
                 else:  # if body is missing
                     self.logger.debug('Using the new syntax rules')
 
@@ -1084,6 +1120,9 @@ class Preprocessor(BasePreprocessor):
                             donor_md_path = include_link + options.get('path')
                             self.logger.debug(f'Set the link of the included file to {recipient_md_path}: {donor_md_path} (3)')
 
+                            if self.includes_map_anchors:
+                                donor_anchors = self._add_anchors(donor_anchors, processed_content_part)
+
                     elif options.get('url'):
                         self.logger.debug('File to get by URL referenced')
 
@@ -1109,20 +1148,26 @@ class Preprocessor(BasePreprocessor):
                             sethead=current_sethead,
                             nohead=options.get('nohead')
                         )
-                        
+
                         if self.includes_map_enable:
                             donor_md_path = options['url']
                             self.logger.debug(f'Set the URL of the included file to {recipient_md_path}: {donor_md_path} (4)')
+
+                            if self.includes_map_anchors:
+                                donor_anchors = self._add_anchors(donor_anchors, processed_content_part)
 
                     elif options.get('src'):
                         self.logger.debug('Local file referenced')
 
                         included_file_path = self._get_included_file_path(options.get('src'), markdown_file_path)
                         self.logger.debug(f'Resolved path to the included file: {included_file_path}')
-                        
+
                         if self.includes_map_enable:
                             donor_md_path = self._prepare_path_for_includes_map(included_file_path)
                             self.logger.debug(f'Set the path of the included file to {recipient_md_path}: {donor_md_path} (5)')
+
+                            if self.includes_map_anchors:
+                                donor_anchors = self._add_anchors(donor_anchors, processed_content_part)
 
                         if options.get('project_root'):
                             current_project_root_path = (
@@ -1203,10 +1248,18 @@ class Preprocessor(BasePreprocessor):
                 if self.includes_map_enable:
                     if donor_md_path:
                         if not self._exist_in_includes_map(self.includes_map, recipient_md_path):
-                            self.includes_map.append({ 'file': recipient_md_path, "includes": [] })
+                            if not self.includes_map_anchors:
+                                self.includes_map.append({ 'file': recipient_md_path, "includes": []})
+                            else:
+                                self.includes_map.append({ 'file': recipient_md_path, "includes": [], 'anchors': []})
+
                         for i, f in enumerate(self.includes_map):
                             if f['file'] == recipient_md_path:
                                 self.includes_map[i]['includes'].append(donor_md_path)
+
+                                if self.includes_map_anchors:
+                                    for anchor in donor_anchors:
+                                        self.includes_map[i]['anchors'].append(anchor)
 
             else:
                 processed_content_part = content_part
@@ -1243,7 +1296,7 @@ class Preprocessor(BasePreprocessor):
         return source_files_extensions
 
     def apply(self):
-       
+
         self.logger.info('Applying preprocessor')
 
         # Cleaning up downloads because the content of remote source may have modified
@@ -1265,7 +1318,7 @@ class Preprocessor(BasePreprocessor):
                 if processed_content:
                     with open(source_file_path, 'w', encoding='utf8') as processed_file:
                         processed_file.write(processed_content)
-                        
+
         # Write includes map
         if self.includes_map_enable:
             output = f'{self.working_dir}/static/includes_map.json'

--- a/foliant/preprocessors/includes.py
+++ b/foliant/preprocessors/includes.py
@@ -1,13 +1,13 @@
 import re
 import urllib
-import json
-import os
 from shutil import rmtree
 from io import StringIO
 from hashlib import md5
 from pathlib import Path
 import socket
 from subprocess import run, CalledProcessError, PIPE, STDOUT
+from json import dump
+from os import getcwd
 
 
 from foliant.preprocessors.base import BasePreprocessor
@@ -23,7 +23,7 @@ class Preprocessor(BasePreprocessor):
         'cache_dir': Path('.includescache'),
         'aliases': {},
         'extensions': ['md'],
-        'includes_map': False
+        'includes_map': True
     }
 
     tags = 'include',
@@ -843,8 +843,8 @@ class Preprocessor(BasePreprocessor):
         if path.as_posix().startswith(self.working_dir.as_posix()):
             _path = path.relative_to(self.working_dir)
             donor_path = f"{self.src_dir}/{_path.as_posix()}"
-        elif path.as_posix().startswith(os.getcwd()):
-            _path = path.relative_to(os.getcwd())
+        elif path.as_posix().startswith(getcwd()):
+            _path = path.relative_to(getcwd())
             if _path.as_posix().startswith(self.working_dir.as_posix()):
                 _path = _path.relative_to(self.working_dir)
                 if _path.as_posix().startswith(self.working_dir.as_posix()):
@@ -1270,7 +1270,7 @@ class Preprocessor(BasePreprocessor):
             output = f'{self.working_dir}/static/includes_map.json'
             Path(f'{self.working_dir}/static/').mkdir(parents=True, exist_ok=True)
             with open(f'{self.working_dir}/static/includes_map.json', 'w', encoding='utf8') as f:
-                json.dump(self.includes_map, f)
+                dump(self.includes_map, f)
             self.logger.debug(f'includes_map write to {output}')
 
         self.logger.info('Preprocessor applied')

--- a/foliant/preprocessors/includes.py
+++ b/foliant/preprocessors/includes.py
@@ -46,13 +46,14 @@ class Preprocessor(BasePreprocessor):
         self._cache_dir_path = self.project_path / self.options['cache_dir']
         self._downloaded_dir_path = self._cache_dir_path / '_downloaded_content'
         self.src_dir = self.config.get("src_dir")
-        self.includes_map_enable = False
-        self.includes_map_anchors = False
+        self.includes_map_enable = True # TODO: the default value is False
+        self.includes_map_anchors = True # TODO: the default value is False
         if 'includes_map' in self.options:
             self.includes_map_enable = True
-            self.includes_map = []
             if 'anchors' in self.options['includes_map']:
                 self.includes_map_anchors = True
+        if self.includes_map_enable:
+            self.includes_map = []
 
         self.logger = self.logger.getChild('includes')
 

--- a/foliant/preprocessors/includes.py
+++ b/foliant/preprocessors/includes.py
@@ -902,12 +902,6 @@ class Preprocessor(BasePreprocessor):
                 body = self._tag_body_pattern.match(include_statement.group('body').strip())
                 options = self.get_options(include_statement.group('options'))
 
-                self.logger.debug(f'Include pair: {markdown_file_path} <- {options} {body}')
-                
-                # TODO: 
-                # :param markdown_file_path:
-                # :returns date:
-
                 self.logger.debug(
                     f'Processing include statement; body: {body}, options: {options}, ' +
                     f'current project root path: {current_project_root_path}'

--- a/foliant/preprocessors/includes.py
+++ b/foliant/preprocessors/includes.py
@@ -23,7 +23,7 @@ class Preprocessor(BasePreprocessor):
         'cache_dir': Path('.includescache'),
         'aliases': {},
         'extensions': ['md'],
-        'includes_map': False
+        'includes_map': True
     }
 
     tags = 'include',

--- a/foliant/preprocessors/includes.py
+++ b/foliant/preprocessors/includes.py
@@ -1058,7 +1058,7 @@ class Preprocessor(BasePreprocessor):
                             include_link=include_link
                         )
 
-                        donor_md_path = include_link
+                        donor_md_path = include_link + options.get('path')
                         
                         self.logger.debug(f'Set the link of the included file to {recipient_md_path}: {donor_md_path} (3)')
 

--- a/foliant/preprocessors/includes.py
+++ b/foliant/preprocessors/includes.py
@@ -854,7 +854,7 @@ class Preprocessor(BasePreprocessor):
         :returns: Markdown content with resolved includes
         '''
 
-        recipient_md_path = markdown_file_path.relative_to(self.working_dir).as_posix()
+        recipient_md_path = f'{self.src_dir}/{markdown_file_path.relative_to(self.working_dir).as_posix()}'
         markdown_file_path = markdown_file_path.resolve()
 
         self.logger.debug(f'Processing Markdown file: {markdown_file_path}')
@@ -1175,7 +1175,7 @@ class Preprocessor(BasePreprocessor):
                     if self.includes_map.get(recipient_md_path) == None :
                         self.includes_map[recipient_md_path] = []
 
-                    self.includes_map[recipient_md_path].append({"path": donor_md_path})
+                    self.includes_map[recipient_md_path].append(donor_md_path)
 
             else:
                 processed_content_part = content_part
@@ -1224,6 +1224,7 @@ class Preprocessor(BasePreprocessor):
             for source_file_path in self.working_dir.rglob(source_files_extension):
                 with open(source_file_path, encoding='utf8') as source_file:
                     source_content = source_file.read()
+
                 processed_content = self.process_includes(
                     source_file_path,
                     source_content,

--- a/foliant/preprocessors/includes.py
+++ b/foliant/preprocessors/includes.py
@@ -46,12 +46,9 @@ class Preprocessor(BasePreprocessor):
         self._cache_dir_path = self.project_path / self.options['cache_dir']
         self._downloaded_dir_path = self._cache_dir_path / '_downloaded_content'
         self.src_dir = self.config.get("src_dir")
-        self.includes_map_enable = True # TODO: the default value is False
-        self.includes_map_anchors = True # TODO: the default value is False
+        self.includes_map_enable = False
         if 'includes_map' in self.options:
             self.includes_map_enable = True
-            if 'anchors' in self.options['includes_map']:
-                self.includes_map_anchors = True
         if self.includes_map_enable:
             self.includes_map = []
 
@@ -1021,9 +1018,6 @@ class Preprocessor(BasePreprocessor):
                             donor_md_path = included_file_path.as_posix()
                             self.logger.debug(f'Set the repo URL of the included file to {recipient_md_path}: {donor_md_path} (1)')
 
-                            if self.includes_map_anchors:
-                                donor_anchors = self._add_anchors(donor_anchors, processed_content_part)
-
                         if included_file_path.name.startswith('^'):
                             included_file_path = self._find_file(
                                 included_file_path.name[1:], included_file_path.parent
@@ -1078,9 +1072,6 @@ class Preprocessor(BasePreprocessor):
                             donor_md_path = self._prepare_path_for_includes_map(included_file_path)
                             self.logger.debug(f'Set the path of the included file to {recipient_md_path}: {donor_md_path} (2)')
 
-                            if self.includes_map_anchors:
-                                donor_anchors = self._add_anchors(donor_anchors, processed_content_part)
-
                 else:  # if body is missing
                     self.logger.debug('Using the new syntax rules')
 
@@ -1121,9 +1112,6 @@ class Preprocessor(BasePreprocessor):
                             donor_md_path = include_link + options.get('path')
                             self.logger.debug(f'Set the link of the included file to {recipient_md_path}: {donor_md_path} (3)')
 
-                            if self.includes_map_anchors:
-                                donor_anchors = self._add_anchors(donor_anchors, processed_content_part)
-
                     elif options.get('url'):
                         self.logger.debug('File to get by URL referenced')
 
@@ -1154,9 +1142,6 @@ class Preprocessor(BasePreprocessor):
                             donor_md_path = options['url']
                             self.logger.debug(f'Set the URL of the included file to {recipient_md_path}: {donor_md_path} (4)')
 
-                            if self.includes_map_anchors:
-                                donor_anchors = self._add_anchors(donor_anchors, processed_content_part)
-
                     elif options.get('src'):
                         self.logger.debug('Local file referenced')
 
@@ -1166,9 +1151,6 @@ class Preprocessor(BasePreprocessor):
                         if self.includes_map_enable:
                             donor_md_path = self._prepare_path_for_includes_map(included_file_path)
                             self.logger.debug(f'Set the path of the included file to {recipient_md_path}: {donor_md_path} (5)')
-
-                            if self.includes_map_anchors:
-                                donor_anchors = self._add_anchors(donor_anchors, processed_content_part)
 
                         if options.get('project_root'):
                             current_project_root_path = (
@@ -1249,18 +1231,11 @@ class Preprocessor(BasePreprocessor):
                 if self.includes_map_enable:
                     if donor_md_path:
                         if not self._exist_in_includes_map(self.includes_map, recipient_md_path):
-                            if not self.includes_map_anchors:
-                                self.includes_map.append({ 'file': recipient_md_path, "includes": []})
-                            else:
-                                self.includes_map.append({ 'file': recipient_md_path, "includes": [], 'anchors': []})
+                            self.includes_map.append({ 'file': recipient_md_path, "includes": []})
 
                         for i, f in enumerate(self.includes_map):
                             if f['file'] == recipient_md_path:
                                 self.includes_map[i]['includes'].append(donor_md_path)
-
-                                if self.includes_map_anchors:
-                                    for anchor in donor_anchors:
-                                        self.includes_map[i]['anchors'].append(anchor)
 
             else:
                 processed_content_part = content_part

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     description=SHORT_DESCRIPTION,
     long_description=LONG_DESCRIPTION,
     long_description_content_type='text/markdown',
-    version='1.1.17',
+    version='1.1.18',
     author='Konstantin Molchanov',
     author_email='moigagoo@live.com',
     url='https://github.com/foliant-docs/foliantcontrib.includes',

--- a/test/test_includes.py
+++ b/test/test_includes.py
@@ -243,3 +243,21 @@ class TestIncludesBasic(TestCase):
             'index.j2': '# My title\n\nIncluded content',
             'sub/sub.md': 'Included content'
         }
+
+    def test_includes_map(self):
+        self.ptf.options = {'includes_map': True }
+        input_map = {
+            'index.md': '# My title\n\n<include src="sub/sub-1.md"></include>\n\n<include src="sub/sub-2.md"></include>',
+            'sub/sub-1.md': 'Included content 1',
+            'sub/sub-2.md': 'Included content 2'
+        }
+        expected_map = {
+            'index.md': '# My title\n\nIncluded content 1\n\nIncluded content 2',
+            'static/includes_map.json': "[{\"file\": \"__src__/index.md\", \"includes\": [\"__src__/sub/sub-1.md\", \"__src__/sub/sub-2.md\"]}]",
+            'sub/sub-1.md': 'Included content 1',
+            'sub/sub-2.md': 'Included content 2'
+        }
+        self.ptf.test_preprocessor(
+            input_mapping=input_map,
+            expected_mapping=expected_map,
+        )


### PR DESCRIPTION
Added generation of the `includes_map.json` containing information about files inserted using the includes preprocessor.

From this file, third-party services can get information about the presence of inclusions in files, for example, to check links with a linter.

- [x] add option
- [x] add a merge of the includes maps for multiproject (https://github.com/foliant-docs/foliantcontrib.multiproject/pull/3)
- [x] ~add a list of added anchors~ it will be decided in a separate PR (https://github.com/foliant-docs/foliantcontrib.includes/pull/28)
- [x] fix tests
- [x] add test includes map
- [x] add an badge for tests