### PR TITLE
fix: duplicate anchors, version 1.1.20

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# 1.1.20
+
+- Fix: bug where the `_adjust_links` duplicated the anchor.
+
 # 1.1.19
 
 - Add: anchor link parsing for the includes map.

--- a/foliant/preprocessors/includes.py
+++ b/foliant/preprocessors/includes.py
@@ -658,7 +658,6 @@ class Preprocessor(BasePreprocessor):
                     self.logger.debug(
                         f'An error {exception} occurred when resolving the link: {m.group("path")}'
                     )
-                    link = m.group('path')
 
             return f'[{caption}]({link}{anchor})'
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     description=SHORT_DESCRIPTION,
     long_description=LONG_DESCRIPTION,
     long_description_content_type='text/markdown',
-    version='1.1.19',
+    version='1.1.20',
     author='Konstantin Molchanov',
     author_email='moigagoo@live.com',
     url='https://github.com/foliant-docs/foliantcontrib.includes',


### PR DESCRIPTION
- Fixed a bug where the `_adjust_links` duplicated the anchor.